### PR TITLE
add parser to report status code

### DIFF
--- a/nginx/timings.py
+++ b/nginx/timings.py
@@ -96,6 +96,35 @@ def parse_nginx_counter(logger, line):
     })
 
 
+def parse_nginx_status(logger, line):
+    if not line:
+        return None
+
+    try:
+        timestamp, http_method, url, status_code, request_time, domain = _parse_line(line)
+    except Exception:
+        logger.exception('Failed to parse log line')
+        return None
+
+    if _should_skip_log(url):
+        return None
+
+    # Convert the metric value into a float
+    request_time = float(request_time.strip())
+
+    url_group = _get_url_group(url)
+
+    # Return the output as a tuple
+    return ('nginx.status_code.' + status_code, timestamp, 1, {
+        'metric_type': 'counter',
+        'url_group': url_group,
+        'url': url,
+        'status_code': status_code,
+        'http_method': http_method,
+        'domain': domain,
+    })
+
+
 def _get_url_group(url):
     default = 'other'
     if url.startswith('/a/' + WILDCARD):

--- a/tests/test_couch/test_couch_parsers.py
+++ b/tests/test_couch/test_couch_parsers.py
@@ -14,7 +14,7 @@ class TestCouchLogParser(unittest.TestCase):
         metric_name, timestamp, request_time, attrs = parse_couch_logs(logging, SIMPLE)
 
         self.assertEqual(metric_name, 'couch.timings')
-        self.assertEqual(timestamp, 1446309123.0)
+        self.assertEqual(timestamp, 1446330723.0)
         self.assertEqual(request_time, 0.191515)
         self.assertEqual(attrs['metric_type'], 'gauge')
         self.assertEqual(attrs['url'], '/a/*/receiver/*/')

--- a/tests/test_nginx/test_nginx_timings_parser.py
+++ b/tests/test_nginx/test_nginx_timings_parser.py
@@ -1,6 +1,12 @@
 import logging
 import unittest
-from nginx.timings import parse_nginx_timings, parse_nginx_apdex, parse_nginx_counter, _get_url_group
+from nginx.timings import (
+    parse_nginx_timings,
+    parse_nginx_apdex,
+    parse_nginx_counter,
+    parse_nginx_status,
+    _get_url_group
+)
 from nose_parameterized import parameterized
 
 logging.basicConfig(level=logging.DEBUG)
@@ -20,7 +26,7 @@ class TestNginxTimingsParser(unittest.TestCase):
         metric_name, timestamp, request_time, attrs = parse_nginx_timings(logging, SIMPLE)
 
         self.assertEqual(metric_name, 'nginx.timings')
-        self.assertEqual(timestamp, 1446038294.0)
+        self.assertEqual(timestamp, 1446059894.0)
         self.assertEqual(request_time, 0.242)
         self.assertEqual(attrs['metric_type'], 'gauge')
         self.assertEqual(attrs['url'], '/a/*/api/case/attachment/*/VH016899R9_000839_20150922T034026.MP4')
@@ -60,7 +66,20 @@ class TestNginxTimingsParser(unittest.TestCase):
         metric_name, timestamp, count, attrs = parse_nginx_counter(logging, SIMPLE)
 
         self.assertEqual(metric_name, 'nginx.requests')
-        self.assertEqual(timestamp, 1446038294.0)
+        self.assertEqual(timestamp, 1446059894.0)
+        self.assertEqual(count, 1)
+        self.assertEqual(attrs['metric_type'], 'counter')
+        self.assertEqual(attrs['url'], '/a/*/api/case/attachment/*/VH016899R9_000839_20150922T034026.MP4')
+        self.assertEqual(attrs['url_group'], 'api')
+        self.assertEqual(attrs['status_code'], '401')
+        self.assertEqual(attrs['http_method'], 'GET')
+        self.assertEqual(attrs['domain'], 'uth-rhd')
+
+    def test_parse_nginx_status(self):
+        metric_name, timestamp, count, attrs = parse_nginx_status(logging, SIMPLE)
+
+        self.assertEqual(metric_name, 'nginx.status_code.401')
+        self.assertEqual(timestamp, 1446059894.0)
         self.assertEqual(count, 1)
         self.assertEqual(attrs['metric_type'], 'counter')
         self.assertEqual(attrs['url'], '/a/*/api/case/attachment/*/VH016899R9_000839_20150922T034026.MP4')


### PR DESCRIPTION
@snopoke @benrudolph I think that this is all we need to report on nginx status codes. I double checked that icds-timing.log has 503s in it. What's the best way to test it? https://github.com/dimagi/commcarehq-ansible/pull/695

@millerdev 