### PR TITLE
Add nginx.error_logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+---
+language: python
+python: "2.7"
+
+install:
+  - pip install -r requirements.txt
+
+script:
+  - "nosetests"

--- a/couch/parsers.py
+++ b/couch/parsers.py
@@ -1,7 +1,10 @@
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import re
 import collections
-import time
 from datetime import datetime
+from parsing_utils import get_unix_timestamp
 
 """
 Sample log line:
@@ -47,7 +50,7 @@ def _parse_line(line):
     string_date = '{} {}'.format(date1, date2).split(',')[0]
 
     date = datetime.strptime(string_date, "%Y-%m-%d %H:%M:%S")
-    timestamp = time.mktime(date.timetuple())
+    timestamp = get_unix_timestamp(date)
 
     # Strip off first to letters which are [: and last letter which is a closing ]
     domain = _sanitize_domain(username_domain)

--- a/nginx/errors.py
+++ b/nginx/errors.py
@@ -1,5 +1,9 @@
+import os
+import sys
+from parsing_utils import get_unix_timestamp
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import re
-import time
 from collections import namedtuple
 from datetime import datetime
 
@@ -67,6 +71,5 @@ def _parse_line(line):
 
 
 def _parse_timestamp(string_date):
-    print string_date
     date = datetime.strptime(string_date, "%Y/%m/%d %H:%M:%S")
-    return time.mktime(date.timetuple())
+    return get_unix_timestamp(date)

--- a/nginx/errors.py
+++ b/nginx/errors.py
@@ -1,0 +1,72 @@
+import re
+import time
+from collections import namedtuple
+from datetime import datetime
+
+
+SHARED_DETAILS_REGEXES = [
+    r'(?P<timestamp>\d\d\d\d/\d\d/\d\d \d\d:\d\d:\d\d) \[(?P<log_level>\w+)\].*'
+]
+
+TYPE_REGEXES = [
+    (r'connect\(\) failed \(111: Connection refused\) while connecting to upstream', 'connection_refused'),
+    (r'an upstream response is buffered to a temporary file', 'buffered_to_file')
+]
+
+
+LogDetails = namedtuple('LogDetails', ['timestamp', 'log_level', 'error_type'])
+
+
+def parse_nginx_errors(logger, line):
+    details = _get_log_details(logger, line)
+    if not details:
+        return None
+
+    return 'nginx.error_logs', details.timestamp, 1, {
+        'metric_type': 'counter',
+        'log_level': details.log_level,
+        'error_type': details.error_type,
+    }
+
+
+def _get_log_details(logger, line):
+    if not line:
+        return None
+
+    try:
+        details = _parse_line(line)
+    except Exception:
+        logger.exception('Failed to parse log line')
+        return None
+
+    return details
+
+
+def _parse_line(line):
+    groupdict = None
+    for regex in SHARED_DETAILS_REGEXES:
+        match = re.match(regex, line)
+        if match:
+            groupdict = match.groupdict()
+            break
+
+    if not groupdict:
+        raise Exception('No parsers match line: "{}"'.format(line))
+
+    for regex, error_type in TYPE_REGEXES:
+        if re.search(regex, line):
+            break
+    else:
+        error_type = 'other'
+
+    return LogDetails(
+        timestamp=_parse_timestamp(groupdict['timestamp']),
+        log_level=groupdict['log_level'],
+        error_type=error_type,
+    )
+
+
+def _parse_timestamp(string_date):
+    print string_date
+    date = datetime.strptime(string_date, "%Y/%m/%d %H:%M:%S")
+    return time.mktime(date.timetuple())

--- a/nginx/timings.py
+++ b/nginx/timings.py
@@ -1,5 +1,9 @@
+import os
+import sys
+from parsing_utils import get_unix_timestamp
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import re
-import time
 from collections import namedtuple
 from datetime import datetime
 
@@ -174,7 +178,7 @@ def _extract_domain(all_fields, _):
 
 def _parse_timestamp(_, string_date):
     date = datetime.strptime(string_date, "%d/%b/%Y:%H:%M:%S +0000")
-    return time.mktime(date.timetuple())
+    return get_unix_timestamp(date)
 
 
 def _request_time_to_float(_, duration):

--- a/parsing_utils.py
+++ b/parsing_utils.py
@@ -1,0 +1,22 @@
+import calendar
+
+
+def get_unix_timestamp(naive_datetime_representing_utc):
+    return calendar.timegm(naive_datetime_representing_utc.utctimetuple())
+
+
+class UnixTimestampTestMixin(object):
+    def assert_timestamp_equal(self, actual_timestamp, expected_utc_datetime, expected_timestamp=None):
+        """
+        this is a nice way to force the writer of a test that includes testing timestamps
+        to include _both_ the actual timestamp int _and_ the utc datetime it represents
+        """
+
+        if expected_timestamp is not None:
+            # assert the writer of the test's datetime and timestamp match
+            self.assertEqual(get_unix_timestamp(expected_utc_datetime), expected_timestamp)
+            # assert the timestamp under test matches the expected value
+            self.assertEqual(actual_timestamp, expected_timestamp)
+        else:
+            # help the writer of the test by generating the timestamp for them
+            self.fail("Use this timestamp value: {}".format(get_unix_timestamp(expected_utc_datetime)))

--- a/tests/test_couch/test_couch_parsers.py
+++ b/tests/test_couch/test_couch_parsers.py
@@ -1,6 +1,8 @@
 import logging
 import unittest
+import datetime
 from couch.parsers import parse_couch_logs
+from parsing_utils import UnixTimestampTestMixin
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -11,7 +13,7 @@ WITH_USERNAME = "2017-05-04 12:20:21,416 [123@my-dom.commcarehq.org:my-dom] /a/m
 BORKED = 'Borked'
 
 
-class TestCouchLogParser(unittest.TestCase):
+class TestCouchLogParser(UnixTimestampTestMixin, unittest.TestCase):
 
     def _test_log_parsing(self, line, expected_timestamp, expected_request_time, expected_attrs):
         metric_name, timestamp, request_time, attrs = parse_couch_logs(logging, line)
@@ -22,12 +24,12 @@ class TestCouchLogParser(unittest.TestCase):
         })
 
         self.assertEqual(metric_name, 'couch.timings')
-        self.assertEqual(expected_timestamp, timestamp)
+        self.assert_timestamp_equal(timestamp, *expected_timestamp)
         self.assertEqual(expected_request_time, request_time)
         self.assertEqual(expected_attrs, attrs)
 
     def test_simple_log_parsing(self):
-        self._test_log_parsing(SIMPLE, 1446309123.0, 0.191515, {
+        self._test_log_parsing(SIMPLE, (datetime.datetime(2015, 10, 31, 18, 32, 03, 963), 1446316323), 0.191515, {
             'url': '/a/*/receiver/*/',
             'couch_url': '*',
             'status_code': 'None',
@@ -36,7 +38,7 @@ class TestCouchLogParser(unittest.TestCase):
         })
 
     def test_log_parsing_content_length(self):
-        self._test_log_parsing(WITH_CONTENT_LENGTH, 1493893218.0, 0.007104, {
+        self._test_log_parsing(WITH_CONTENT_LENGTH, (datetime.datetime(2017, 5, 4, 12, 20, 18, 957), 1493900418), 0.007104, {
             'url': '/a/*/apps/download/*/modules-*/forms-*.xml',
             'couch_url': '/commcarehq__apps/',
             'status_code': '200',
@@ -45,7 +47,7 @@ class TestCouchLogParser(unittest.TestCase):
         })
 
     def test_log_parsing_database_name(self):
-        self._test_log_parsing(WITH_DATABASE_NAME, 1493893221.0, 0.004401, {
+        self._test_log_parsing(WITH_DATABASE_NAME, (datetime.datetime(2017, 5, 4, 12, 20, 21, 416), 1493900421), 0.004401, {
             'url': '/a/*/receiver/secure/*/',
             'couch_url': '_design/users/_view/by_username',
             'status_code': '200',
@@ -54,7 +56,7 @@ class TestCouchLogParser(unittest.TestCase):
         })
 
     def test_log_parsing_username(self):
-        self._test_log_parsing(WITH_USERNAME, 1493893221.0, 0.004076, {
+        self._test_log_parsing(WITH_USERNAME, (datetime.datetime(2017, 5, 4, 12, 20, 21, 416), 1493900421), 0.004076, {
             'url': '/a/*/phone/restore/*/',
             'couch_url': '/commcarehq/',
             'status_code': '200',

--- a/tests/test_nginx/test_nginx_errors_parser.py
+++ b/tests/test_nginx/test_nginx_errors_parser.py
@@ -1,9 +1,9 @@
 import logging
 import unittest
 import datetime
-import time
 from nginx.errors import parse_nginx_errors
 from nose_parameterized import parameterized
+from parsing_utils import UnixTimestampTestMixin
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -11,12 +11,12 @@ ERROR_CONNECTION_REFUSED = '2018/01/03 19:04:31 [error] 22548#22548: *16560854 c
 WARN_BUFFERED_TO_FILE = '2018/01/03 19:46:16 [warn] 22552#22552: *16562567 an upstream response is buffered to a temporary file /var/lib/nginx/proxy/9/22/0001234567 while reading upstream, client: 123.12.1.1, server: www.commcarehq.org, request: "GET /a/dimagi/phone/restore/?version=2.0&since=3a740800856321c7b45c4dcf9b72982e&device_id=WebAppsLogin*user1@dimagi_commcarehq_org*as*123456&case_sync=livequery&as=123456@dimagi.commcarehq.org HTTP/1.1", upstream: "http://172.25.2.6:9010/a/dimagi/phone/restore/?version=2.0&since=3a740800856321c7b45c4dcf9b72982e&device_id=WebAppsLogin*user1@dimagi_commcarehq_org*as*123456&case_sync=livequery&as=123456@dimagi.commcarehq.org", host: "www.commcarehq.org"'
 
 
-class TestNginxErrorsParser(unittest.TestCase):
+class TestNginxErrorsParser(UnixTimestampTestMixin, unittest.TestCase):
 
     def test_error_connection_refused(self):
         metric_name, timestamp, one, attrs = parse_nginx_errors(logging, ERROR_CONNECTION_REFUSED)
         self.assertEqual(metric_name, 'nginx.error_logs')
-        self.assertEqual(timestamp, time.mktime(datetime.datetime(2018, 1, 3, 19, 4, 31).timetuple()))
+        self.assert_timestamp_equal(timestamp, datetime.datetime(2018, 1, 3, 19, 4, 31), 1515006271)
         self.assertEqual(one, 1)
         self.assertEqual(attrs['metric_type'], 'counter')
 
@@ -26,7 +26,7 @@ class TestNginxErrorsParser(unittest.TestCase):
     def test_warn_buffered_to_file(self):
         metric_name, timestamp, one, attrs = parse_nginx_errors(logging, WARN_BUFFERED_TO_FILE)
         self.assertEqual(metric_name, 'nginx.error_logs')
-        self.assertEqual(timestamp, time.mktime(datetime.datetime(2018, 1, 3, 19, 46, 16).timetuple()))
+        self.assert_timestamp_equal(timestamp, datetime.datetime(2018, 1, 3, 19, 46, 16), 1515008776)
         self.assertEqual(one, 1)
         self.assertEqual(attrs['metric_type'], 'counter')
 

--- a/tests/test_nginx/test_nginx_errors_parser.py
+++ b/tests/test_nginx/test_nginx_errors_parser.py
@@ -1,0 +1,34 @@
+import logging
+import unittest
+import datetime
+import time
+from nginx.errors import parse_nginx_errors
+from nose_parameterized import parameterized
+
+logging.basicConfig(level=logging.DEBUG)
+
+ERROR_CONNECTION_REFUSED = '2018/01/03 19:04:31 [error] 22548#22548: *16560854 connect() failed (111: Connection refused) while connecting to upstream, client: 123.12.123.12, server: www.commcarehq.org, request: "GET /a/dimagi/apps/view/ba37c12fd8c9ab8cff511e0a8d7db19b/current_version/ HTTP/2.0", upstream: "http://10.1.1.1:9010/a/dimagi/apps/view/ba37c12fd8c9ab8cff511e0a8d7db19b/current_version/", host: "www.commcarehq.org", referrer: "https://www.commcarehq.org/a/dimagi/apps/view/ba37c12fd8c9ab8cff511e0a8d7db19b/form/8e025b83c9a4c606f133f52cea6ffd5f/"'
+WARN_BUFFERED_TO_FILE = '2018/01/03 19:46:16 [warn] 22552#22552: *16562567 an upstream response is buffered to a temporary file /var/lib/nginx/proxy/9/22/0001234567 while reading upstream, client: 123.12.1.1, server: www.commcarehq.org, request: "GET /a/dimagi/phone/restore/?version=2.0&since=3a740800856321c7b45c4dcf9b72982e&device_id=WebAppsLogin*user1@dimagi_commcarehq_org*as*123456&case_sync=livequery&as=123456@dimagi.commcarehq.org HTTP/1.1", upstream: "http://172.25.2.6:9010/a/dimagi/phone/restore/?version=2.0&since=3a740800856321c7b45c4dcf9b72982e&device_id=WebAppsLogin*user1@dimagi_commcarehq_org*as*123456&case_sync=livequery&as=123456@dimagi.commcarehq.org", host: "www.commcarehq.org"'
+
+
+class TestNginxErrorsParser(unittest.TestCase):
+
+    def test_error_connection_refused(self):
+        metric_name, timestamp, one, attrs = parse_nginx_errors(logging, ERROR_CONNECTION_REFUSED)
+        self.assertEqual(metric_name, 'nginx.error_logs')
+        self.assertEqual(timestamp, time.mktime(datetime.datetime(2018, 1, 3, 19, 4, 31).timetuple()))
+        self.assertEqual(one, 1)
+        self.assertEqual(attrs['metric_type'], 'counter')
+
+        self.assertEqual(attrs['log_level'], 'error')
+        self.assertEqual(attrs['error_type'], 'connection_refused')
+
+    def test_warn_buffered_to_file(self):
+        metric_name, timestamp, one, attrs = parse_nginx_errors(logging, WARN_BUFFERED_TO_FILE)
+        self.assertEqual(metric_name, 'nginx.error_logs')
+        self.assertEqual(timestamp, time.mktime(datetime.datetime(2018, 1, 3, 19, 46, 16).timetuple()))
+        self.assertEqual(one, 1)
+        self.assertEqual(attrs['metric_type'], 'counter')
+
+        self.assertEqual(attrs['log_level'], 'warn')
+        self.assertEqual(attrs['error_type'], 'buffered_to_file')

--- a/tests/test_nginx/test_nginx_timings_parser.py
+++ b/tests/test_nginx/test_nginx_timings_parser.py
@@ -1,7 +1,9 @@
 import logging
 import unittest
+import datetime
 from nginx.timings import parse_nginx_timings, parse_nginx_apdex, parse_nginx_counter, _get_url_group, _sanitize_url
 from nose_parameterized import parameterized
+from parsing_utils import UnixTimestampTestMixin
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -18,13 +20,12 @@ CACHE_BLANK = '[13/Sep/2017:12:34:14 +0000] - POST /a/hki-nepal-suaahara-2/recei
 URL_SPACES = '[01/Sep/2017:07:19:09 +0000] GET /a/infomovel-ccs/apps/download/81630cfff87fdc77b8fd4a7427703bdc/media_profile.ccpr?latest=true&profile=None loira fabiao bila HTTP/1.1 400 0.001'
 
 
-class TestNginxTimingsParser(unittest.TestCase):
+class TestNginxTimingsParser(UnixTimestampTestMixin, unittest.TestCase):
 
     def test_basic_log_parsing(self):
         metric_name, timestamp, request_time, attrs = parse_nginx_timings(logging, SIMPLE)
-
         self.assertEqual(metric_name, 'nginx.timings')
-        self.assertEqual(timestamp, 1446038294.0)
+        self.assert_timestamp_equal(timestamp, datetime.datetime(2015, 10, 28, 15, 18, 14), 1446045494)
         self.assertEqual(request_time, 0.242)
         self.assertEqual(attrs['metric_type'], 'gauge')
         self.assertEqual(attrs['url'], 'not_stored')
@@ -77,7 +78,7 @@ class TestNginxTimingsParser(unittest.TestCase):
         metric_name, timestamp, count, attrs = parse_nginx_counter(logging, SIMPLE)
 
         self.assertEqual(metric_name, 'nginx.requests')
-        self.assertEqual(timestamp, 1446038294.0)
+        self.assert_timestamp_equal(timestamp, datetime.datetime(2015, 10, 28, 15, 18, 14), 1446045494)
         self.assertEqual(count, 1)
         self.assertEqual(attrs['metric_type'], 'counter')
         self.assertEqual(attrs['url_group'], 'api')
@@ -101,7 +102,7 @@ class TestNginxTimingsParser(unittest.TestCase):
     def test_cache(self):
         metric_name, timestamp, count, attrs = parse_nginx_counter(logging, CACHE)
         self.assertEqual(metric_name, 'nginx.requests')
-        self.assertEqual(timestamp, 1504289683.0)
+        self.assert_timestamp_equal(timestamp, datetime.datetime(2017, 9, 1, 20, 14, 43), 1504296883)
         self.assertEqual(count, 1)
         self.assertEqual(attrs['metric_type'], 'counter')
         self.assertEqual(attrs['url_group'], 'apps')
@@ -116,7 +117,7 @@ class TestNginxTimingsParser(unittest.TestCase):
     def test_url_with_spaces(self):
         metric_name, timestamp, count, attrs = parse_nginx_timings(logging, URL_SPACES)
         self.assertEqual(metric_name, 'nginx.timings')
-        self.assertEqual(timestamp, 1504243149.0)
+        self.assert_timestamp_equal(timestamp, datetime.datetime(2017, 9, 1, 7, 19, 9), 1504250349)
         self.assertEqual(count, 0.001)
         self.assertEqual(attrs['status_code'], '400')
         self.assertEqual(attrs['http_method'], 'GET')

--- a/tests/test_parsing_utils.py
+++ b/tests/test_parsing_utils.py
@@ -1,0 +1,8 @@
+import unittest
+import datetime
+from parsing_utils import get_unix_timestamp
+
+
+class TestParsingUtils(unittest.TestCase):
+    def test_get_unix_timestamp(self):
+        self.assertEqual(get_unix_timestamp(datetime.datetime(2015, 10, 28, 15, 18, 14)), 1446045494)

--- a/tests/test_parsing_utils.py
+++ b/tests/test_parsing_utils.py
@@ -6,3 +6,6 @@ from parsing_utils import get_unix_timestamp
 class TestParsingUtils(unittest.TestCase):
     def test_get_unix_timestamp(self):
         self.assertEqual(get_unix_timestamp(datetime.datetime(2015, 10, 28, 15, 18, 14)), 1446045494)
+
+    def test_get_unix_timestamp_on_epoch(self):
+        self.assertEqual(get_unix_timestamp(datetime.datetime(1970, 1, 1)), 0)


### PR DESCRIPTION
adding `nginx.error_logs` was supposed to be the payload here, but to get the tests running, I had to track down a really annoying timezone issue that has apparently been plaguing this code from day one—and that ended up really stealing the show here.

## about `nginx.error_logs`

This new metric is intended for use on `{env}_commcare-nginx_error.log`. It's a counter on the number of lines in the file by timestamp, and it includes the tags `log_level` (`warn`, `error`, etc.) and `error_type` which is detected based on a list of known error messages (currently `connection_refused`, `buffered_to_file`, defaulting to `other`).

## about the timezone issue

From https://docs.python.org/2/library/time.html#time.mktime:
> This is the inverse function of localtime(). Its argument is the struct_time or full 9-tuple (since the dst flag is needed; use -1 as the dst flag if it is unknown) which expresses the time in _local_ time, not UTC.

(emphasis theirs, but is also mine)
  