### PR TITLE
Revert "record url for errors"

### DIFF
--- a/nginx/timings.py
+++ b/nginx/timings.py
@@ -12,17 +12,16 @@ PARSER_RX = [
 ]
 
 TIMING_TAGS = {
-    'http_method': None,
-    'status_code': None,
+    'http_method',
+    'status_code',
 }
 
 APDEX_TAGS = TIMING_TAGS
 
 REQUEST_TAGS = {
-    'http_method': None,
-    'status_code': None,
-    'cache_status': None,
-    'url': lambda d: d.status_code == '500',
+    'http_method',
+    'status_code',
+    'cache_status'
 }
 
 TIMING_WHITELIST_URL_GROUP = ('/home/', '/pricing/', 'icds_dashboard')
@@ -35,7 +34,7 @@ class LogDetails(namedtuple('LogDetails', 'timestamp, cache_status, http_method,
             del tags['cache_status']
 
         for tag in tags:
-            if tag not in tag_whitelist or (tag_whitelist[tag] and not tag_whitelist[tag](self)):
+            if tag not in tag_whitelist:
                 del tags[tag]
 
         tags.update(kwargs)

--- a/tests/test_nginx/test_nginx_timings_parser.py
+++ b/tests/test_nginx/test_nginx_timings_parser.py
@@ -20,7 +20,6 @@ HOME = '[01/Sep/2017:20:14:43 +0000] GET /home/ HTTP/1.1 200 18.067'
 CACHE = '[01/Sep/2017:20:14:43 +0000] HIT GET /a/icds-cas/apps/download/01d133d7c6264247bf0155f7c5e1af03/modules-11/forms-6.xml?profile=c708a9f737d147bfa57781dd46935502 HTTP/1.1 200 18.067'
 CACHE_BLANK = '[13/Sep/2017:12:34:14 +0000] - POST /a/hki-nepal-suaahara-2/receiver/secure/393a1d06a6e8422092c089082ffb5c01/ HTTP/1.1 401 0.955"'
 URL_SPACES = '[01/Sep/2017:07:19:09 +0000] GET /a/infomovel-ccs/apps/download/81630cfff87fdc77b8fd4a7427703bdc/media_profile.ccpr?latest=true&profile=None loira fabiao bila HTTP/1.1 400 0.001'
-STATUS_500 = '[01/Sep/2017:20:14:43 +0000] GET /home/ HTTP/1.1 500 18.067'
 
 
 class TestNginxTimingsParser(UnixTimestampTestMixin, unittest.TestCase):
@@ -124,6 +123,7 @@ class TestNginxTimingsParser(UnixTimestampTestMixin, unittest.TestCase):
         metric_name, timestamp, count, attrs = parse_nginx_counter(logging, CACHE_BLANK)
         self.assertEqual(attrs['cache_status'], '-')
 
+
     def test_url_with_spaces(self):
         metric_name, timestamp, count, attrs = parse_nginx_timings(logging, URL_SPACES)
         self.assertEqual(metric_name, 'nginx.timings')
@@ -131,8 +131,3 @@ class TestNginxTimingsParser(UnixTimestampTestMixin, unittest.TestCase):
         self.assertEqual(count, 0.001)
         self.assertEqual(attrs['status_code'], '400')
         self.assertEqual(attrs['http_method'], 'GET')
-
-    def test_url_tag_on_500(self):
-        metric_name, timestamp, count, attrs = parse_nginx_counter(logging, STATUS_500)
-        self.assertEqual(attrs['status_code'], '500')
-        self.assertEqual(attrs['url'], '/home/')


### PR DESCRIPTION
Reverts dimagi/datadog-parsers#24

Don't actually need this since we already have url_group tag