### PR TITLE
Add back url_group info to nginx.timings

### DIFF
--- a/nginx/timings.py
+++ b/nginx/timings.py
@@ -24,8 +24,6 @@ REQUEST_TAGS = {
     'cache_status'
 }
 
-TIMING_WHITELIST_URL_GROUP = ('/home/', '/pricing/', 'icds_dashboard')
-
 
 class LogDetails(namedtuple('LogDetails', 'timestamp, cache_status, http_method, url, status_code, request_time, domain')):
     def to_tags(self, tag_whitelist, **kwargs):
@@ -68,7 +66,7 @@ def parse_nginx_timings(logger, line):
     if not details:
         return None
 
-    url_group = _get_url_group(details.url, TIMING_WHITELIST_URL_GROUP)
+    url_group = _get_url_group(details.url)
 
     return 'nginx.timings', details.timestamp, details.request_time, details.to_tags(
         TIMING_TAGS,
@@ -121,7 +119,7 @@ def _get_log_details(logger, line):
     return details
 
 
-def _get_url_group(url, whitelist=None):
+def _get_url_group(url):
     default = 'other'
     group = default
     if url.startswith('/a/' + WILDCARD):
@@ -130,7 +128,7 @@ def _get_url_group(url, whitelist=None):
     elif url in ('/home/', '/pricing/'):  # track certain urls individually
         group = url
 
-    return group if not whitelist or group in whitelist else 'not_stored'
+    return group
 
 
 def _should_skip_log(url):

--- a/tests/test_nginx/test_nginx_timings_parser.py
+++ b/tests/test_nginx/test_nginx_timings_parser.py
@@ -7,7 +7,8 @@ from parsing_utils import UnixTimestampTestMixin
 
 logging.basicConfig(level=logging.DEBUG)
 
-SIMPLE = '[28/Oct/2015:15:18:14 +0000] GET /a/uth-rhd/api/case/attachment/a26f2e21-5f24-48b6-b283-200a21f79bb6/VH016899R9_000839_20150922T034026.MP4 HTTP/1.1 401 0.242'
+SIMPLE = '[28/Oct/2015:15:18:14 +0000] GET /favicon.ico HTTP/1.1 401 0.242'
+API = '[28/Oct/2015:15:18:14 +0000] GET /a/uth-rhd/api/case/attachment/a26f2e21-5f24-48b6-b283-200a21f79bb6/VH016899R9_000839_20150922T034026.MP4 HTTP/1.1 401 0.242'
 PRICING = '[28/Oct/2015:15:18:14 +0000] GET /pricing/ HTTP/1.1 401 0.242'
 ICDS_DASHBOARD = '[28/Oct/2015:15:18:14 +0000] GET /a/anydomain/icds_dashboard/anything HTTP/1.1 401 0.242'
 TOLERATING = '[28/Oct/2015:15:18:14 +0000] GET /a/uth-rhd HTTP/1.1 401 3.2'
@@ -25,7 +26,8 @@ URL_SPACES = '[01/Sep/2017:07:19:09 +0000] GET /a/infomovel-ccs/apps/download/81
 class TestNginxTimingsParser(UnixTimestampTestMixin, unittest.TestCase):
 
     @parameterized.expand([
-        ('not_stored', SIMPLE),
+        ('other', SIMPLE),
+        ('api', API),
         ('icds_dashboard', ICDS_DASHBOARD),
         ('/pricing/', PRICING),
     ])
@@ -67,7 +69,7 @@ class TestNginxTimingsParser(UnixTimestampTestMixin, unittest.TestCase):
 
 
     def test_apdex_parser_satisfied(self):
-        metric_name, timestamp, apdex_score, attrs = parse_nginx_apdex(logging, SIMPLE)
+        metric_name, timestamp, apdex_score, attrs = parse_nginx_apdex(logging, API)
         self.assertEqual(apdex_score, 1)
 
     def test_apdex_parser_tolerating(self):
@@ -79,11 +81,11 @@ class TestNginxTimingsParser(UnixTimestampTestMixin, unittest.TestCase):
         self.assertEqual(apdex_score, 0)
 
     def test_nginx_counter(self):
-        metric_name, timestamp, count, attrs = parse_nginx_apdex(logging, SIMPLE)
+        metric_name, timestamp, count, attrs = parse_nginx_apdex(logging, API)
         self.assertEqual(count, 1)
 
     def test_parse_nginx_counter(self):
-        metric_name, timestamp, count, attrs = parse_nginx_counter(logging, SIMPLE)
+        metric_name, timestamp, count, attrs = parse_nginx_counter(logging, API)
 
         self.assertEqual(metric_name, 'nginx.requests')
         self.assert_timestamp_equal(timestamp, datetime.datetime(2015, 10, 28, 15, 18, 14), 1446045494)


### PR DESCRIPTION
We collect the "`url_group`" ("apps" for `/*/apps/...`, "receiver" for `/*/receiver/...`, etc.) for `nginx.requests` (which counts the total number of requests we get to nginx, tagged with the "duration bucket"—lt_1s, lt_5s, lt_20s, etc.). We used to also collect it for `nginx.timings`, which records the exact timing for each request and allows us to graph the average, median, 95p, max, etc of all nginx timings. Adding the `url_group` to this  metric will let us do this by part of the site, which may help pin down exactly where we're seeing slowness and maybe even zoom in on possible causes.