### PR TITLE
Split out formplayer urls in nginx parser

### DIFF
--- a/nginx/timings.py
+++ b/nginx/timings.py
@@ -25,7 +25,10 @@ REQUEST_TAGS = {
 }
 
 # These patterns are to be tried _in order_
+# Group name is given by the `group_name` matching group, with the second element as fallback
 URL_PATTERN_GROUPS = [
+    (re.compile(r'^/a/[^/]*/(?P<group_name>phone/[^/]*)'), None),
+    (re.compile(r'^/a/[^/]*/(?P<group_name>[^/]*)'), None),
     # Exact match
     (re.compile(r'^/home/$'), '/home/'),
     (re.compile(r'^/pricing/$'), '/pricing/'),
@@ -147,17 +150,11 @@ def _get_log_details(logger, line):
 
 def _get_url_group(url):
     default = 'other'
-    if url.startswith('/a/' + WILDCARD):
-        parts = url.split('/')
-        group = parts[3] if len(parts) >= 4 else default
-        if group == 'phone':
-            return 'phone/{}'.format(parts[4])
-        return group
-    else:
-        for pattern, group_name in URL_PATTERN_GROUPS:
-            if pattern.search(url):
-                return group_name
-        return default
+    for pattern, group_name in URL_PATTERN_GROUPS:
+        match = pattern.search(url)
+        if match:
+            return match.groupdict().get('group_name', group_name)
+    return default
 
 
 def _should_skip_log(url):

--- a/nginx/timings.py
+++ b/nginx/timings.py
@@ -24,11 +24,19 @@ REQUEST_TAGS = {
     'cache_status'
 }
 
-STATIC_GROUPS = {
-    '/home/': '/home/',
-    '/pricing/': '/pricing/',
-    '/accounts/login/': 'login'
-}
+# These patterns are to be tried _in order_
+URL_PATTERN_GROUPS = [
+    # Exact match
+    (re.compile(r'^/home/$'), '/home/'),
+    (re.compile(r'^/pricing/$'), '/pricing/'),
+    (re.compile(r'^/accounts/login/$'), 'login'),
+    # Prefix match
+    (re.compile(r'^/formplayer/'), 'formplayer'),
+    (re.compile(r'^/hq/multimedia/file/CommCareAudio/'), 'mm/audio'),
+    (re.compile(r'^/hq/multimedia/file/CommCareVideo/'), 'mm/video'),
+    (re.compile(r'^/hq/multimedia/file/CommCareImage/'), 'mm/image'),
+    (re.compile(r'^/hq/multimedia/file/'), 'mm/other'),
+]
 
 MM_MAPPING = {
     'CommCareAudio': 'mm/audio',
@@ -145,11 +153,11 @@ def _get_url_group(url):
         if group == 'phone':
             return 'phone/{}'.format(parts[4])
         return group
-    elif url.startswith('/hq/multimedia/file/'):
-        parts = url.split('/')
-        return MM_MAPPING.get(parts[4], 'mm/other')
     else:
-        return STATIC_GROUPS.get(url, default)
+        for pattern, group_name in URL_PATTERN_GROUPS:
+            if pattern.search(url):
+                return group_name
+        return default
 
 
 def _should_skip_log(url):

--- a/nginx/timings.py
+++ b/nginx/timings.py
@@ -27,8 +27,8 @@ REQUEST_TAGS = {
 # These patterns are to be tried _in order_
 # Group name is given by the `group_name` matching group, with the second element as fallback
 URL_PATTERN_GROUPS = [
-    (re.compile(r'^/a/[^/]*/(?P<group_name>phone/[^/]*)'), None),
-    (re.compile(r'^/a/[^/]*/(?P<group_name>[^/]*)'), None),
+    (re.compile(r'^/a/[^/]+/(?P<group_name>phone/[^/]+)'), None),
+    (re.compile(r'^/a/[^/]+/(?P<group_name>[^/]+)'), None),
     # Exact match
     (re.compile(r'^/home/$'), '/home/'),
     (re.compile(r'^/pricing/$'), '/pricing/'),

--- a/tests/test_nginx/test_nginx_timings_parser.py
+++ b/tests/test_nginx/test_nginx_timings_parser.py
@@ -104,11 +104,16 @@ class TestNginxTimingsParser(UnixTimestampTestMixin, unittest.TestCase):
         ('/a/*/cloudcare', 'cloudcare'),
         ('/pricing/', '/pricing/'),
         ('/home/', '/home/'),
+        ('/accounts/login/', 'login'),
+        ('/accounts/login/noggin', 'other'),
         ('/a/*/phone/heartbeat/123456/', 'phone/heartbeat'),
         ('/hq/multimedia/file/CommCareAudio/123456/some-audio.mp3', 'mm/audio'),
         ('/hq/multimedia/file/CommCareVideo/123456/vid_daily_feeding.mp4', 'mm/video'),
         ('/hq/multimedia/file/CommCareImage/123456/module4_form0_en.png', 'mm/image'),
+        ('/hq/multimedia/file/', 'mm/other'),
+        ('/hq/multimedia/file/vile', 'mm/other'),
         ('/formplayer/navigate_menu', 'formplayer'),
+        ('/formplayer/', 'formplayer'),
     ])
     def test_get_url_group(self, url, expected):
         group = _get_url_group(url)

--- a/tests/test_nginx/test_nginx_timings_parser.py
+++ b/tests/test_nginx/test_nginx_timings_parser.py
@@ -1,7 +1,8 @@
 import logging
 import unittest
 import datetime
-from nginx.timings import parse_nginx_timings, parse_nginx_apdex, parse_nginx_counter, _get_url_group, _sanitize_url
+from nginx.timings import parse_nginx_timings, parse_nginx_apdex, parse_nginx_counter, \
+    _get_url_group, _sanitize_url, URL_PATTERN_GROUPS
 from nose_parameterized import parameterized
 from parsing_utils import UnixTimestampTestMixin
 
@@ -112,6 +113,12 @@ class TestNginxTimingsParser(UnixTimestampTestMixin, unittest.TestCase):
     def test_get_url_group(self, url, expected):
         group = _get_url_group(url)
         self.assertEqual(expected, group)
+
+    def test_pattern_format(self):
+        for pattern, group_name in URL_PATTERN_GROUPS:
+            self.assert_('?P<group_name>' in pattern.pattern or group_name is not None,
+                         "If there is no capturing group (?P<group_name>) in the pattern, "
+                         "there needs to be a default: {}".format(pattern.pattern))
 
     def test_nginx_formplayer(self):
         self.assertIsNotNone(parse_nginx_timings(logging, FORMPLAYER))

--- a/tests/test_nginx/test_nginx_timings_parser.py
+++ b/tests/test_nginx/test_nginx_timings_parser.py
@@ -107,6 +107,7 @@ class TestNginxTimingsParser(UnixTimestampTestMixin, unittest.TestCase):
         ('/hq/multimedia/file/CommCareAudio/123456/some-audio.mp3', 'mm/audio'),
         ('/hq/multimedia/file/CommCareVideo/123456/vid_daily_feeding.mp4', 'mm/video'),
         ('/hq/multimedia/file/CommCareImage/123456/module4_form0_en.png', 'mm/image'),
+        ('/formplayer/navigate_menu', 'formplayer'),
     ])
     def test_get_url_group(self, url, expected):
         group = _get_url_group(url)


### PR DESCRIPTION
This also refactors to unify the logic for special url naming rules to a single list of patterns to match and labels to give.