### PR TITLE
Add referer group parsing to nginx timings

### DIFF
--- a/nginx/timings.py
+++ b/nginx/timings.py
@@ -114,12 +114,14 @@ def parse_nginx_counter(logger, line):
         return None
 
     url_group = _get_url_group(details.url)
+    referer_group = _get_url_group(details.referer) if details.referer else 'unknown'
 
     return 'nginx.requests', details.timestamp, 1, details.to_tags(
         REQUEST_TAGS,
         metric_type='counter',
         url_group=url_group,
-        duration=get_duration_bucket(details.request_time)
+        duration=get_duration_bucket(details.request_time),
+        referer_group=referer_group,
     )
 
 


### PR DESCRIPTION
This adds referer parsing for datadog similar to what we do for url groups. Its added such that no current logs would break if this were deployed without the referrer being in the timing log.

Adding this after discussing with @ctsims about better understanding the ICDS dashboard's uptime metrics as there are currently a lot of AJAX requests on page loads that can fail.