### PR TITLE
add couch.requests metric with bucketed timings

### DIFF
--- a/tests/test_couch/test_couch_parsers.py
+++ b/tests/test_couch/test_couch_parsers.py
@@ -17,7 +17,7 @@ BORKED = 'Borked'
 class TestCouchLogParser(UnixTimestampTestMixin, unittest.TestCase):
 
     def _test_log_parsing(self, line, expected_timestamp, expected_request_time, expected_attrs):
-        metric_name, timestamp, request_time, attrs = parse_couch_logs(logging, line)
+        metric_name, timestamp, request_time, attrs = parse_couch_logs(logging, line)[0]
 
         expected_attrs.update({
             'metric_type': 'gauge',


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-12083

Add `couch.requests` counter metric with duration added as a bucketed tag.