### PR TITLE
add ability to parse celery task from log line

### DIFF
--- a/couch/parsers.py
+++ b/couch/parsers.py
@@ -19,21 +19,22 @@ def parse_couch_logs(logger, line):
         return None
 
     try:
-        timestamp, domain, url, database, http_method, status_code, couch_url, request_seconds = _parse_line(line)
+        timestamp, domain, url, task, database, http_method, status_code, couch_url, request_seconds = _parse_line(line)
     except Exception:
         logger.exception('Failed to parse log line')
         return None
 
     return [
-        get_couch_timing_gauge(timestamp, url, database, http_method, status_code, couch_url, request_seconds),
-        get_couch_requests_counter(timestamp, url, database, http_method, status_code, couch_url, request_seconds)
+        get_couch_timing_gauge(timestamp, url, task, database, http_method, status_code, couch_url, request_seconds),
+        get_couch_requests_counter(timestamp, url, task, database, http_method, status_code, couch_url, request_seconds)
     ]
 
 
-def get_couch_timing_gauge(timestamp, url, database, http_method, status_code, couch_url, request_seconds):
+def get_couch_timing_gauge(timestamp, url, task, database, http_method, status_code, couch_url, request_seconds):
     return 'couch.timings', timestamp, request_seconds, {
         'metric_type': 'gauge',
         'url': url,
+        'task': task,
         'database': database,
         'http_method': http_method,
         'status_code': status_code,
@@ -41,10 +42,11 @@ def get_couch_timing_gauge(timestamp, url, database, http_method, status_code, c
     }
 
 
-def get_couch_requests_counter(timestamp, url, database, http_method, status_code, couch_url, request_seconds):
+def get_couch_requests_counter(timestamp, url, task, database, http_method, status_code, couch_url, request_seconds):
     return 'couch.requests', timestamp, 1, {
         'metric_type': 'counter',
         'url': url,
+        'task': task,
         'database': database,
         'http_method': http_method,
         'status_code': status_code,
@@ -56,7 +58,11 @@ def get_couch_requests_counter(timestamp, url, database, http_method, status_cod
 def _parse_line(line):
     pieces = line.split()
     database = ''
-    if len(pieces) == 10:
+    task_name = ''
+    if len(pieces) == 11:
+        # celery task added: https://github.com/dimagi/commcare-hq/pull/29542
+        date1, date2, username_domain, url, task_name, database, http_method, status_code, content_length, couch_url, request_time = pieces
+    elif len(pieces) == 10:
         # database name added: https://github.com/dimagi/couchdbkit/pull/22
         date1, date2, username_domain, url, database, http_method, status_code, content_length, couch_url, request_time = pieces
     elif len(pieces) == 9:
@@ -74,7 +80,8 @@ def _parse_line(line):
     # Strip off first to letters which are [: and last letter which is a closing ]
     domain = _sanitize_domain(username_domain)
 
-    url = _sanitize_url(url)
+    if url and url != '-':
+        url = _sanitize_url(url)
     couch_url = _sanitize_couch_url(couch_url)
 
     if ":" in request_time:
@@ -83,7 +90,7 @@ def _parse_line(line):
     else:
         request_seconds = float(request_time)
 
-    return timestamp, domain, url, database, http_method, status_code, couch_url, request_seconds
+    return timestamp, domain, url, task_name, database, http_method, status_code, couch_url, request_seconds
 
 
 def _sanitize_url(url):

--- a/tests/test_couch/test_couch_parsers.py
+++ b/tests/test_couch/test_couch_parsers.py
@@ -7,6 +7,9 @@ from parsing_utils import UnixTimestampTestMixin
 logging.basicConfig(level=logging.DEBUG)
 
 SIMPLE = '2015-10-31 18:32:03,963 [:mvp-pampaida] /a/mvp-pampaida/receiver/630916e49084b142c0a5a69c3a52b9b3/ PUT None d3abf611f2acdc7b4c32f7ebf4982a88 0:00:00.191515'
+URL_NO_TASK = '2015-10-31 18:32:03,963 [:mvp-pampaida] /a/mvp-pampaida/receiver/630916e49084b142c0a5a69c3a52b9b3/ - commcarehq PUT 200 None d3abf611f2acdc7b4c32f7ebf4982a88 0:00:00.191515'
+NO_URL_NO_TASK = '2015-10-31 18:32:03,963 [:mvp-pampaida] - - commcarehq PUT 200 None d3abf611f2acdc7b4c32f7ebf4982a88 0:00:00.191515'
+NO_URL_TASK = '2015-10-31 18:32:03,963 [:mvp-pampaida] - corehq.apps.tasks.build_app commcarehq PUT 200 None d3abf611f2acdc7b4c32f7ebf4982a88 0:00:00.191515'
 WITH_CONTENT_LENGTH = '2017-05-04 12:20:18,957 [:icds-cas] /a/icds-cas/apps/download/768932dcb27f35c63cdbb830c202c727/modules-0/forms-0.xml HEAD 200 258 /commcarehq__apps/ 0:00:00.007104'
 WITH_DATABASE_NAME = '2017-05-04 12:20:21,416 [:icds-cas] /a/icds-cas/receiver/secure/768932dcb27f35c63cdbb830c202c727/ commcarehq__users GET 200 None _design/users/_view/by_username 0:00:00.004401'
 WITH_USERNAME = "2017-05-04 12:20:21,416 [123@my-dom.commcarehq.org:my-dom] /a/my-dom/phone/restore/768932dcb27f35c63cdbb830c202c727/ HEAD 200 260 /commcarehq/ 0:00:00.004076"
@@ -28,6 +31,7 @@ class TestCouchLogParser(UnixTimestampTestMixin, unittest.TestCase):
         self.assert_timestamp_equal(timestamp, *expected_timestamp)
         self.assertEqual(expected_request_time, request_time)
         self.assertEqual(expected_attrs, attrs)
+        return attrs
 
     def test_simple_log_parsing(self):
         self._test_log_parsing(SIMPLE, (datetime.datetime(2015, 10, 31, 18, 32, 03, 963), 1446316323), 0.191515, {
@@ -35,7 +39,8 @@ class TestCouchLogParser(UnixTimestampTestMixin, unittest.TestCase):
             'couch_url': '*',
             'status_code': 'None',
             'http_method': 'PUT',
-            'database': ''
+            'database': '',
+            'task': '',
         })
 
     def test_log_parsing_content_length(self):
@@ -44,7 +49,8 @@ class TestCouchLogParser(UnixTimestampTestMixin, unittest.TestCase):
             'couch_url': '/commcarehq__apps/',
             'status_code': '200',
             'http_method': 'HEAD',
-            'database': ''
+            'database': '',
+            'task': '',
         })
 
     def test_log_parsing_database_name(self):
@@ -53,7 +59,8 @@ class TestCouchLogParser(UnixTimestampTestMixin, unittest.TestCase):
             'couch_url': '_design/users/_view/by_username',
             'status_code': '200',
             'http_method': 'GET',
-            'database': 'commcarehq__users'
+            'database': 'commcarehq__users',
+            'task': '',
         })
 
     def test_log_parsing_username(self):
@@ -62,7 +69,8 @@ class TestCouchLogParser(UnixTimestampTestMixin, unittest.TestCase):
             'couch_url': '/commcarehq/',
             'status_code': '200',
             'http_method': 'HEAD',
-            'database': ''
+            'database': '',
+            'task': '',
         })
 
     def test_log_parsing_seconds(self):
@@ -71,8 +79,39 @@ class TestCouchLogParser(UnixTimestampTestMixin, unittest.TestCase):
             'couch_url': '/commcarehq/',
             'status_code': '200',
             'http_method': 'HEAD',
-            'database': ''
+            'database': '',
+            'task': '',
         })
 
     def test_borked_log_line(self):
         self.assertIsNone(parse_couch_logs(logging, BORKED))
+
+    def test_url_no_task(self):
+        self._test_log_parsing(URL_NO_TASK, (datetime.datetime(2015, 10, 31, 18, 32, 03, 963), 1446316323), 0.191515, {
+            'url': '/a/*/receiver/*/',
+            'couch_url': '*',
+            'status_code': '200',
+            'http_method': 'PUT',
+            'database': 'commcarehq',
+            'task': '-',
+        })
+
+    def test_no_url_no_task(self):
+        self._test_log_parsing(NO_URL_NO_TASK, (datetime.datetime(2015, 10, 31, 18, 32, 03, 963), 1446316323), 0.191515, {
+            'url': '-',
+            'couch_url': '*',
+            'status_code': '200',
+            'http_method': 'PUT',
+            'database': 'commcarehq',
+            'task': '-',
+        })
+
+    def test_no_url_task(self):
+        self._test_log_parsing(NO_URL_TASK, (datetime.datetime(2015, 10, 31, 18, 32, 03, 963), 1446316323), 0.191515, {
+            'url': '-',
+            'couch_url': '*',
+            'status_code': '200',
+            'http_method': 'PUT',
+            'database': 'commcarehq',
+            'task': 'corehq.apps.tasks.build_app',
+        })


### PR DESCRIPTION
Build on https://github.com/dimagi/datadog-parsers/pull/38 to add support for parsing celery task name from the log lines.

See https://github.com/dimagi/commcare-hq/pull/29542/